### PR TITLE
Create personal portfolio logo

### DIFF
--- a/brand/logo-manu-vaya-icon.svg
+++ b/brand/logo-manu-vaya-icon.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+<title id="title">MV Pin — Manu Vaya</title>
+<desc id="desc">Icon-only location pin with MV monogram and gradient fill.</desc>
+
+<defs>
+	<linearGradient id="mvGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+		<stop offset="0%" stop-color="#14b8a6"/>
+		<stop offset="100%" stop-color="#3b82f6"/>
+	</linearGradient>
+	<filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
+		<feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0b1220" flood-opacity="0.18"/>
+	</filter>
+</defs>
+
+<g transform="translate(56,16) scale(1.0)" filter="url(#softShadow)">
+	<!-- Pin silhouette -->
+	<path d="M200 0 C 89.5 0 0 89.5 0 200 C 0 350 200 512 200 512 C 200 512 400 350 400 200 C 400 89.5 310.5 0 200 0 Z" fill="url(#mvGrad)"/>
+	<!-- MV monogram -->
+	<g stroke="#ffffff" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" fill="none">
+		<path d="M90 340 L90 160"/>
+		<path d="M90 160 L200 340 L310 160"/>
+		<path d="M310 160 L310 340"/>
+	</g>
+</g>
+
+</svg>
+

--- a/brand/logo-manu-vaya.svg
+++ b/brand/logo-manu-vaya.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="400" viewBox="0 0 1200 400" role="img" aria-labelledby="title desc">
+<title id="title">Manu Vaya — Travel With Virtual With Me</title>
+<desc id="desc">Primary horizontal logo lockup featuring a gradient location-pin monogram and wordmark.</desc>
+
+<defs>
+	<linearGradient id="mvGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+		<stop offset="0%" stop-color="#14b8a6"/>
+		<stop offset="100%" stop-color="#3b82f6"/>
+	</linearGradient>
+	<filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
+		<feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#0b1220" flood-opacity="0.18"/>
+	</filter>
+	<style>
+		text { font-family: "Montserrat", "Poppins", "Segoe UI", Ubuntu, Arial, sans-serif; }
+	</style>
+</defs>
+
+<!-- Logo Mark -->
+<g id="mark" transform="translate(60,20)" filter="url(#softShadow)">
+	<!-- Pin silhouette -->
+	<path d="M150 10 C 67 10 0 77 0 160 C 0 280 150 390 150 390 C 150 390 300 280 300 160 C 300 77 233 10 150 10 Z" fill="url(#mvGrad)"/>
+	<!-- MV monogram (knockout-style with white strokes) -->
+	<g stroke="#ffffff" stroke-width="18" stroke-linecap="round" stroke-linejoin="round" fill="none">
+		<!-- Left vertical of M -->
+		<path d="M70 260 L70 120"/>
+		<!-- Middle V of M -->
+		<path d="M70 120 L150 260 L230 120"/>
+		<!-- Right vertical of M (also reads as part of V) -->
+		<path d="M230 120 L230 260"/>
+	</g>
+</g>
+
+<!-- Wordmark -->
+<g id="wordmark" transform="translate(420,120)">
+	<text x="0" y="0" font-size="96" font-weight="700" fill="#0f172a" letter-spacing="0.5">
+		<tspan x="0" dy="0">Manu Vaya</tspan>
+	</text>
+	<text x="0" y="70" font-size="34" font-weight="500" fill="#334155" opacity="0.9" letter-spacing="0.3">
+		<tspan x="0" dy="0">Travel With Virtual With Me</tspan>
+	</text>
+</g>
+
+</svg>
+


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:

Adds new SVG logo files for a personal portfolio, as requested by the user.

- **`brand/logo-manu-vaya.svg`**: Full horizontal lockup with "Manu Vaya" and slogan "Travel With Virtual With Me".
- **`brand/logo-manu-vaya-icon.svg`**: Icon-only location pin with "MV" monogram.

Both logos feature a teal-to-blue gradient and use Montserrat/Poppins font fallbacks for the text.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8434851-df08-4378-a2e5-f2b846be0d9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8434851-df08-4378-a2e5-f2b846be0d9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

